### PR TITLE
Fix compile issue when the library is used as dependency directly

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -66,6 +66,7 @@ defmodule Avalanche.MixProject do
   defp package() do
     [
       description: "Elixir Snowflake Connector built on top of the Snowflake SQL API v2.",
+      files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG* .version),
       licenses: ["Apache-2.0"],
       links: %{
         "GitHub" => @source_url,


### PR DESCRIPTION
Found this when using the dep directly in a project. Turns out that if you don't have the `.version` file present, it cries.

Repro steps:
- `mix new test`
- add avalanche
- `mix deps.get`

Can also repro if you have avalanche locally and remove the `.version` file.

Error:

```
# test project name was `avalanche_version`
==> avalanche_version
Error while loading project :avalanche at /Users/paulo/dev/random/avalanche_version/deps/avalanche
** (File.Error) could not read file "/Users/paulo/dev/random/avalanche_version/deps/avalanche/.version": no such file or directory
    (elixir 1.14.1) lib/file.ex:358: File.read!/1
    /Users/paulo/dev/random/avalanche_version/deps/avalanche/mix.exs:9: (module)
```