### PR TITLE
fix: Allow warehouse to be overridden in request options

### DIFF
--- a/lib/avalanche.ex
+++ b/lib/avalanche.ex
@@ -247,7 +247,7 @@ defmodule Avalanche do
   """
   @spec available_req_options :: list(atom())
   def available_req_options do
-    ~W(user_agent compressed range http_errors base_url params auth form json compress_body compressed raw decode_body output follow_redirects location_trusted max_redirects retry retry_delay max_retries cache cache_dir plug finch connect_options receive_timeout pool_timeout unix_socket)a
+    ~W(user_agent compressed range http_errors base_url params auth form json compress_body compressed raw decode_body output follow_redirects location_trusted max_redirects retry retry_delay max_retries cache cache_dir plug finch connect_options receive_timeout pool_timeout unix_socket warehouse)a
   end
 
   defp validate_options(options, schema) do


### PR DESCRIPTION
It looks like the `warehouse` request option is being lost when it's provided explicitly.

**Before change:**
```elixir
iex(1)> Keyword.split([warehouse: "foo"], Avalanche.available_req_options)
{[], [warehouse: "foo"]}
```

**After change:**
```elixir
iex(1)> Keyword.split([warehouse: "foo"], Avalanche.available_req_options)
{[warehouse: "foo"], []}
```