### PR TITLE
Include account and user in the cache's key 

### DIFF
--- a/lib/avalanche/token_cache.ex
+++ b/lib/avalanche/token_cache.ex
@@ -91,8 +91,11 @@ defmodule Avalanche.TokenCache do
   defp key_from_options(token) when is_binary(token), do: :crypto.hash(:md5, token)
 
   defp key_from_options(token) do
+    account = Keyword.fetch!(token, :account)
     priv_key = Keyword.fetch!(token, :priv_key)
-    :crypto.hash(:md5, priv_key)
+    user = Keyword.fetch!(token, :user)
+
+    :crypto.hash(:md5, [account, user, priv_key])
   end
 
   # SHA256:public_key_fingerprint

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -271,5 +271,37 @@ defmodule AvalancheIntegrationTest do
 
       assert "TEST-ACCOUNT.TEST-USER.SHA256:" <> _fingerprint = iss
     end
+
+    test "Private Key Token - works as expected for different a user" do
+      {"KEYPAIR_JWT", jwt} =
+        Avalanche.TokenCache.fetch_token(account: "test-account", user: "test-user", priv_key: @priv_key)
+
+      assert {:ok, %{"alg" => "RS256", "typ" => "JWT"}} = Avalanche.JWTs.peek_header(jwt)
+
+      assert {:ok,
+              %{
+                "exp" => _,
+                "iat" => _,
+                "iss" => iss,
+                "sub" => "TEST-ACCOUNT.TEST-USER"
+              }} = Avalanche.JWTs.peek_claims(jwt)
+
+      assert "TEST-ACCOUNT.TEST-USER.SHA256:" <> _fingerprint = iss
+
+      {"KEYPAIR_JWT", jwt2} =
+        Avalanche.TokenCache.fetch_token(account: "test-account-2", user: "test-user2", priv_key: @priv_key)
+
+      assert {:ok, %{"alg" => "RS256", "typ" => "JWT"}} = Avalanche.JWTs.peek_header(jwt2)
+
+      assert {:ok,
+              %{
+                "exp" => _,
+                "iat" => _,
+                "iss" => iss,
+                "sub" => "TEST-ACCOUNT.TEST-USER2"
+              }} = Avalanche.JWTs.peek_claims(jwt2)
+
+      assert "TEST-ACCOUNT.TEST-USER2.SHA256:" <> _fingerprint = iss
+    end
   end
 end


### PR DESCRIPTION
Fixes issue https://github.com/HGInsights/avalanche/issues/47

Add user and account to the MD5 that fetches the cache's key